### PR TITLE
Add berkelium (Bk) chemical element example

### DIFF
--- a/src/data/examples/valid/ChemicalElement-berkelium.yaml
+++ b/src/data/examples/valid/ChemicalElement-berkelium.yaml
@@ -1,0 +1,8 @@
+id: CHEBI:33391 ## berkelium atom
+name: berkelium
+symbol: Bk
+smiles_string: "[Bk]"
+inchi_string: "InChI=1S/Bk"
+atomic_number: 97
+# in_periodic_table_group: actinides
+# in_periodic_table_block: f-block


### PR DESCRIPTION
This PR adds a ChemicalElement example for berkelium (Bk) as requested in issue #2.

## Changes
- Added ChemicalElement-berkelium.yaml in src/data/examples/valid/
- Includes all required fields:
  - id: CHEBI:33391 (berkelium atom)  
  - name: berkelium
  - symbol: Bk
  - atomic_number: 97
  - smiles_string: [Bk]
  - inchi_string: InChI=1S/Bk

## Testing
- Ran make test-examples to ensure the example conforms to the schema
- Follows the same format as the existing carbon example

Addresses: #2