### PR TITLE
Add water solubility and pKa ionization constant properties to ChemROF schema

### DIFF
--- a/examples/output/NaturalProduct-caffeine.json
+++ b/examples/output/NaturalProduct-caffeine.json
@@ -4,6 +4,10 @@
   "type": "chemrof:NaturalProduct",
   "smiles_string": "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",
   "empirical_formula": "C8H10N4O2",
+  "water_solubility": 20.0,
+  "pka_ionization_constant": [
+    10.4
+  ],
   "has_atoms": [
     "C",
     "C",

--- a/examples/output/NaturalProduct-caffeine.yaml
+++ b/examples/output/NaturalProduct-caffeine.yaml
@@ -3,6 +3,9 @@ name: caffeine
 type: chemrof:NaturalProduct
 smiles_string: CN1C=NC2=C1C(=O)N(C(=O)N2C)C
 empirical_formula: C8H10N4O2
+water_solubility: 20.0
+pka_ionization_constant:
+- 10.4
 has_atoms:
 - C
 - C

--- a/examples/output/README.md
+++ b/examples/output/README.md
@@ -32,6 +32,369 @@ name: glucose
 type: chemrof:SmallMolecule
 
 ```
+## SubatomicParticle-proton
+### Input
+```yaml
+id: CHEBI:24636
+name: proton
+subatomic_particle_type: proton
+type: chemrof:SubatomicParticle
+
+```
+## AtomCation-helium2
+### Input
+```yaml
+atomic_number: 2
+elemental_charge: 2
+id: CHEBI:33316
+name: helium(2+)
+symbol: He
+type: chemrof:AtomCation
+
+```
+## PolyatomicIon-ammonium
+### Input
+```yaml
+conjugate_base_of: CHEBI:16134
+empirical_formula: NH+4
+has_atom_occurrences:
+- name: ammonium-n
+  occurrence_of: N
+- name: ammonium-h1
+  occurrence_of: H
+- name: ammonium-h2
+  occurrence_of: H
+- name: ammonium-h3
+  occurrence_of: H
+- name: ammonium-h4
+  occurrence_of: H
+has_bonds:
+- bond_order: 1
+  bond_type: polar covalent
+  object: ammonium-h1
+  subject: ammonium-n
+- bond_order: 1
+  bond_type: polar covalent
+  object: ammonium-h2
+  subject: ammonium-n
+- bond_order: 1
+  bond_type: polar covalent
+  object: ammonium-h3
+  subject: ammonium-n
+- bond_order: 1
+  bond_type: polar covalent
+  object: ammonium-h4
+  subject: ammonium-n
+id: CHEBI:28938
+name: ammonium
+smiles_string: '[NH4+]'
+type: chemrof:PolyatomicIon
+
+```
+## FunctionalGroup-hydroxyl
+### Input
+```yaml
+empirical_formula: OH
+id: CHEBI:43176
+name: hydroxy group
+type: chemrof:FunctionalGroup
+
+```
+## Molecule-dioxygen
+### Input
+```yaml
+empirical_formula: O2
+has_atom_occurrences:
+- name: dioxygen-o1
+  occurrence_of: O
+- name: dioxygen-o2
+  occurrence_of: O
+has_atoms:
+- O
+- O
+has_bonds:
+- bond_order: 2
+  bond_type: covalent
+  object: dioxygen-o2
+  subject: dioxygen-o1
+id: CHEBI:15379
+is_organic: false
+name: dioxygen
+smiles_string: O=O
+type: chemrof:Molecule
+
+```
+## Ester-ethyl_acetate
+### Input
+```yaml
+empirical_formula: C4H8O2
+has_atoms:
+- C
+- C
+- C
+- C
+- H
+- H
+- H
+- H
+- H
+- H
+- H
+- H
+- O
+- O
+id: CHEBI:27750
+is_organic: true
+name: ethyl acetate
+smiles_string: CC(=O)OCC
+type: chemrof:Ester
+
+```
+## AtomAnion-chloride
+### Input
+```yaml
+atomic_number: 17
+elemental_charge: -1
+id: CHEBI:17996
+name: chloride
+symbol: Cl
+type: chemrof:AtomAnion
+
+```
+## NeutralMolecule-water
+### Input
+```yaml
+elemental_charge: 0
+has_atoms:
+- H
+- H
+- O
+id: CHEBI:15377
+is_organic: false
+name: water
+type: chemrof:NeutralMolecule
+
+```
+## Protein-insulin
+### Input
+```yaml
+empirical_formula: C257H383N65O77S6
+id: UniProtKB:P01308
+is_organic: true
+name: insulin
+type: chemrof:Protein
+
+```
+## MolecularAnion-acetate
+### Input
+```yaml
+elemental_charge: -1
+empirical_formula: C2H3O2
+has_atom_occurrences:
+- name: acetate-c1
+  occurrence_of: C
+- name: acetate-c2
+  occurrence_of: C
+- name: acetate-h1
+  occurrence_of: H
+- name: acetate-h2
+  occurrence_of: H
+- name: acetate-h3
+  occurrence_of: H
+- name: acetate-o1
+  occurrence_of: O
+- name: acetate-o2
+  occurrence_of: O
+has_atoms:
+- C
+- C
+- H
+- H
+- H
+- O
+- O
+has_bonds:
+- bond_order: 1
+  bond_type: covalent
+  object: acetate-h1
+  subject: acetate-c1
+- bond_order: 1
+  bond_type: covalent
+  object: acetate-h2
+  subject: acetate-c1
+- bond_order: 1
+  bond_type: covalent
+  object: acetate-h3
+  subject: acetate-c1
+- bond_order: 1
+  bond_type: covalent
+  object: acetate-c2
+  subject: acetate-c1
+- bond_order: 2
+  bond_type: covalent
+  object: acetate-o1
+  subject: acetate-c2
+- bond_order: 1
+  bond_type: covalent
+  object: acetate-o2
+  subject: acetate-c2
+id: CHEBI:30089
+is_organic: true
+name: acetate
+smiles_string: CC(=O)[O-]
+type: chemrof:MolecularAnion
+
+```
+## MonoatomicIon-copper2
+### Input
+```yaml
+elemental_charge: 2
+has_element: Cu
+id: CHEBI:29036
+name: copper(2+)
+type: chemrof:MonoatomicIon
+
+```
+## IsomeraseReaction-glucose_isomerase
+### Input
+```yaml
+id: RHEA:28549
+name: glucose isomerase reaction
+type: chemrof:IsomeraseReaction
+
+```
+## Molecule-water
+### Input
+```yaml
+empirical_formula: H2O
+has_atom_occurrences:
+- name: water-o1
+  occurrence_of: O
+- name: water-h1
+  occurrence_of: H
+- name: water-h2
+  occurrence_of: H
+has_atoms:
+- H
+- H
+- O
+has_bonds:
+- bond_order: 1
+  bond_type: polar covalent
+  object: water-h1
+  subject: water-o1
+- bond_order: 1
+  bond_type: polar covalent
+  object: water-h2
+  subject: water-o1
+id: CHEBI:15377
+is_organic: false
+name: water
+smiles_string: O
+type: chemrof:Molecule
+
+```
+## AtomAnion-fluoride
+### Input
+```yaml
+elemental_charge: -1
+has_element: F
+id: CHEBI:17051
+name: fluoride
+type: chemrof:AtomAnion
+
+```
+## ChemicalElement-carbon
+### Input
+```yaml
+atomic_number: 6
+id: CHEBI:27594
+inchi_string: InChI=1S/C
+name: carbon
+smiles_string: '[C]'
+symbol: C
+
+```
+## ChemicalSalt-sodium_carbonate
+### Input
+```yaml
+empirical_formula: Na2CO3
+id: CHEBI:29377
+name: sodium carbonate
+type: chemrof:ChemicalSalt
+
+```
+## SubatomicParticle-neutron
+### Input
+```yaml
+id: CHEBI:30222
+name: neutron
+subatomic_particle_type: neutron
+type: chemrof:SubatomicParticle
+
+```
+## Collection-nitrites
+### Input
+```yaml
+entities:
+- empirical_formula: "NO\u22122"
+  has_atom_occurrences:
+  - name: _:nitrite-o1
+    occurrence_of: oxygen
+  - name: _:nitrite-o2
+    occurrence_of: oxygen
+  - name: _:nitrite-n1
+    occurrence_of: nitrogen
+  has_bonds:
+  - bond_order: 2
+    bond_type: sigma
+    object: _:nitrite-n1
+    subject: _:nitrite-o1
+  - bond_order: 1
+    bond_type: sigma
+    object: _:nitrite-n1
+    subject: _:nitrite-o2
+  id: CHEBI:16301
+  molecular_mass: 46.005
+  name: nitrite
+  smiles_string: N(=O)[O-]
+  type: chemrof:PolyatomicIon
+- empirical_formula: HNO2
+  has_atom_occurrences:
+  - name: _:nitrous_acid-o1
+    occurrence_of: oxygen
+  - name: _:nitrous_acid-o2
+    occurrence_of: oxygen
+  - name: _:nitrous_acid-n1
+    occurrence_of: nitrogen
+  - name: _:nitrous_acid-h1
+    occurrence_of: hydrogen
+  has_bonds:
+  - bond_order: 2
+    object: _:nitrous_acid-n1
+    subject: _:nitrous_acid-o1
+  - bond_order: 1
+    object: _:nitrous_acid-n1
+    subject: _:nitrous_acid-o2
+  - bond_order: 1
+    object: _:nitrous_acid-h1
+    subject: _:nitrous_acid-o2
+  id: CHEBI:25567
+  molecular_mass: 47.013
+  name: nitrous acid
+  smiles_string: N(=O)O
+  type: chemrof:PolyatomicIon
+
+```
+## SubatomicParticle-electron
+### Input
+```yaml
+id: CHEBI:10545
+name: electron
+subatomic_particle_type: electron
+type: chemrof:SubatomicParticle
+
+```
 ## MolecularCation-methylammonium
 ### Input
 ```yaml
@@ -99,336 +462,13 @@ smiles_string: C[NH3+]
 type: chemrof:MolecularCation
 
 ```
-## Protein-insulin
+## FunctionalGroup-carboxyl
 ### Input
 ```yaml
-empirical_formula: C257H383N65O77S6
-id: UniProtKB:P01308
-is_organic: true
-name: insulin
-type: chemrof:Protein
-
-```
-## UnchargedAtom-hydrogen
-### Input
-```yaml
-atomic_number: 1
-elemental_charge: 0
-id: CHEBI:49637
-name: hydrogen atom
-symbol: H
-type: chemrof:UnchargedAtom
-
-```
-## SubatomicParticle-electron
-### Input
-```yaml
-id: CHEBI:10545
-name: electron
-subatomic_particle_type: electron
-type: chemrof:SubatomicParticle
-
-```
-## FunctionalGroup-hydroxyl
-### Input
-```yaml
-empirical_formula: OH
-id: CHEBI:43176
-name: hydroxy group
+empirical_formula: CO2H
+id: CHEBI:46883
+name: carboxy group
 type: chemrof:FunctionalGroup
-
-```
-## AtomCation-helium2
-### Input
-```yaml
-atomic_number: 2
-elemental_charge: 2
-id: CHEBI:33316
-name: helium(2+)
-symbol: He
-type: chemrof:AtomCation
-
-```
-## Peptide-glycylglycine
-### Input
-```yaml
-empirical_formula: C4H8N2O3
-has_atoms:
-- C
-- C
-- C
-- C
-- H
-- H
-- H
-- H
-- H
-- H
-- H
-- H
-- N
-- N
-- O
-- O
-- O
-id: CHEBI:17201
-is_organic: true
-name: glycylglycine
-smiles_string: C(C(=O)NCC(=O)O)N
-type: chemrof:Peptide
-
-```
-## MonoatomicIon-copper2
-### Input
-```yaml
-elemental_charge: 2
-has_element: Cu
-id: CHEBI:29036
-name: copper(2+)
-type: chemrof:MonoatomicIon
-
-```
-## AtomAnion-chloride
-### Input
-```yaml
-atomic_number: 17
-elemental_charge: -1
-id: CHEBI:17996
-name: chloride
-symbol: Cl
-type: chemrof:AtomAnion
-
-```
-## Molecule-dioxygen
-### Input
-```yaml
-empirical_formula: O2
-has_atom_occurrences:
-- name: dioxygen-o1
-  occurrence_of: O
-- name: dioxygen-o2
-  occurrence_of: O
-has_atoms:
-- O
-- O
-has_bonds:
-- bond_order: 2
-  bond_type: covalent
-  object: dioxygen-o2
-  subject: dioxygen-o1
-id: CHEBI:15379
-is_organic: false
-name: dioxygen
-smiles_string: O=O
-type: chemrof:Molecule
-
-```
-## MolecularAnion-acetate
-### Input
-```yaml
-elemental_charge: -1
-empirical_formula: C2H3O2
-has_atom_occurrences:
-- name: acetate-c1
-  occurrence_of: C
-- name: acetate-c2
-  occurrence_of: C
-- name: acetate-h1
-  occurrence_of: H
-- name: acetate-h2
-  occurrence_of: H
-- name: acetate-h3
-  occurrence_of: H
-- name: acetate-o1
-  occurrence_of: O
-- name: acetate-o2
-  occurrence_of: O
-has_atoms:
-- C
-- C
-- H
-- H
-- H
-- O
-- O
-has_bonds:
-- bond_order: 1
-  bond_type: covalent
-  object: acetate-h1
-  subject: acetate-c1
-- bond_order: 1
-  bond_type: covalent
-  object: acetate-h2
-  subject: acetate-c1
-- bond_order: 1
-  bond_type: covalent
-  object: acetate-h3
-  subject: acetate-c1
-- bond_order: 1
-  bond_type: covalent
-  object: acetate-c2
-  subject: acetate-c1
-- bond_order: 2
-  bond_type: covalent
-  object: acetate-o1
-  subject: acetate-c2
-- bond_order: 1
-  bond_type: covalent
-  object: acetate-o2
-  subject: acetate-c2
-id: CHEBI:30089
-is_organic: true
-name: acetate
-smiles_string: CC(=O)[O-]
-type: chemrof:MolecularAnion
-
-```
-## PolyatomicIon-ammonium
-### Input
-```yaml
-conjugate_base_of: CHEBI:16134
-empirical_formula: NH+4
-has_atom_occurrences:
-- name: ammonium-n
-  occurrence_of: N
-- name: ammonium-h1
-  occurrence_of: H
-- name: ammonium-h2
-  occurrence_of: H
-- name: ammonium-h3
-  occurrence_of: H
-- name: ammonium-h4
-  occurrence_of: H
-has_bonds:
-- bond_order: 1
-  bond_type: polar covalent
-  object: ammonium-h1
-  subject: ammonium-n
-- bond_order: 1
-  bond_type: polar covalent
-  object: ammonium-h2
-  subject: ammonium-n
-- bond_order: 1
-  bond_type: polar covalent
-  object: ammonium-h3
-  subject: ammonium-n
-- bond_order: 1
-  bond_type: polar covalent
-  object: ammonium-h4
-  subject: ammonium-n
-id: CHEBI:28938
-name: ammonium
-smiles_string: '[NH4+]'
-type: chemrof:PolyatomicIon
-
-```
-## Ester-ethyl_acetate
-### Input
-```yaml
-empirical_formula: C4H8O2
-has_atoms:
-- C
-- C
-- C
-- C
-- H
-- H
-- H
-- H
-- H
-- H
-- H
-- H
-- O
-- O
-id: CHEBI:27750
-is_organic: true
-name: ethyl acetate
-smiles_string: CC(=O)OCC
-type: chemrof:Ester
-
-```
-## ChemicalElement-carbon
-### Input
-```yaml
-atomic_number: 6
-id: CHEBI:27594
-inchi_string: InChI=1S/C
-name: carbon
-smiles_string: '[C]'
-symbol: C
-
-```
-## Collection-nitrites
-### Input
-```yaml
-entities:
-- empirical_formula: "NO\u22122"
-  has_atom_occurrences:
-  - name: _:nitrite-o1
-    occurrence_of: oxygen
-  - name: _:nitrite-o2
-    occurrence_of: oxygen
-  - name: _:nitrite-n1
-    occurrence_of: nitrogen
-  has_bonds:
-  - bond_order: 2
-    bond_type: sigma
-    object: _:nitrite-n1
-    subject: _:nitrite-o1
-  - bond_order: 1
-    bond_type: sigma
-    object: _:nitrite-n1
-    subject: _:nitrite-o2
-  id: CHEBI:16301
-  molecular_mass: 46.005
-  name: nitrite
-  smiles_string: N(=O)[O-]
-  type: chemrof:PolyatomicIon
-- empirical_formula: HNO2
-  has_atom_occurrences:
-  - name: _:nitrous_acid-o1
-    occurrence_of: oxygen
-  - name: _:nitrous_acid-o2
-    occurrence_of: oxygen
-  - name: _:nitrous_acid-n1
-    occurrence_of: nitrogen
-  - name: _:nitrous_acid-h1
-    occurrence_of: hydrogen
-  has_bonds:
-  - bond_order: 2
-    object: _:nitrous_acid-n1
-    subject: _:nitrous_acid-o1
-  - bond_order: 1
-    object: _:nitrous_acid-n1
-    subject: _:nitrous_acid-o2
-  - bond_order: 1
-    object: _:nitrous_acid-h1
-    subject: _:nitrous_acid-o2
-  id: CHEBI:25567
-  molecular_mass: 47.013
-  name: nitrous acid
-  smiles_string: N(=O)O
-  type: chemrof:PolyatomicIon
-
-```
-## SubatomicParticle-neutron
-### Input
-```yaml
-id: CHEBI:30222
-name: neutron
-subatomic_particle_type: neutron
-type: chemrof:SubatomicParticle
-
-```
-## AtomCation-sodium
-### Input
-```yaml
-elemental_charge: 1
-has_element: Na
-id: CHEBI:29101
-name: sodium (1+)
-type: chemrof:AtomCation
 
 ```
 ## ChemicalElement-berkelium
@@ -440,6 +480,32 @@ inchi_string: InChI=1S/Bk
 name: berkelium
 smiles_string: '[Bk]'
 symbol: Bk
+
+```
+## Isotope-deuterium
+### Input
+```yaml
+atomic_number: 1
+has_element: H
+id: CHEBI:29237
+isotope_of: CHEBI:49637
+name: deuterium atom
+neutron_number: 1
+symbol: H
+type: chemrof:Isotope
+
+```
+## SmallMolecule-glucose-with-solubility
+### Input
+```yaml
+IUPAC_name: (2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanal
+empirical_formula: CH2O
+id: CHEBI:17234
+molecular_mass: 180.16
+name: glucose
+smiles_string: C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O
+type: chemrof:SmallMolecule
+water_solubility: 909.0
 
 ```
 ## NaturalProduct-caffeine
@@ -474,27 +540,36 @@ has_atoms:
 id: CHEBI:27732
 is_organic: true
 name: caffeine
+pka_ionization_constant:
+- 10.4
 smiles_string: CN1C=NC2=C1C(=O)N(C(=O)N2C)C
 type: chemrof:NaturalProduct
+water_solubility: 20.0
 
 ```
-## AtomAnion-fluoride
+## SmallMolecule-acetic-acid-with-pka
 ### Input
 ```yaml
-elemental_charge: -1
-has_element: F
-id: CHEBI:17051
-name: fluoride
-type: chemrof:AtomAnion
+IUPAC_name: acetic acid
+empirical_formula: C2H4O2
+id: CHEBI:15365
+molecular_mass: 60.05
+name: acetic acid
+pka_ionization_constant:
+- 4.74
+smiles_string: CC(=O)O
+type: chemrof:SmallMolecule
+water_solubility: 1000000.0
 
 ```
-## ChemicalSalt-sodium_carbonate
+## AtomCation-sodium
 ### Input
 ```yaml
-empirical_formula: Na2CO3
-id: CHEBI:29377
-name: sodium carbonate
-type: chemrof:ChemicalSalt
+elemental_charge: 1
+has_element: Na
+id: CHEBI:29101
+name: sodium (1+)
+type: chemrof:AtomCation
 
 ```
 ## Isotope-protium
@@ -510,88 +585,44 @@ symbol: H
 type: chemrof:Isotope
 
 ```
-## Molecule-water
+## Peptide-glycylglycine
 ### Input
 ```yaml
-empirical_formula: H2O
-has_atom_occurrences:
-- name: water-o1
-  occurrence_of: O
-- name: water-h1
-  occurrence_of: H
-- name: water-h2
-  occurrence_of: H
+empirical_formula: C4H8N2O3
 has_atoms:
+- C
+- C
+- C
+- C
 - H
 - H
+- H
+- H
+- H
+- H
+- H
+- H
+- N
+- N
 - O
-has_bonds:
-- bond_order: 1
-  bond_type: polar covalent
-  object: water-h1
-  subject: water-o1
-- bond_order: 1
-  bond_type: polar covalent
-  object: water-h2
-  subject: water-o1
-id: CHEBI:15377
-is_organic: false
-name: water
-smiles_string: O
-type: chemrof:Molecule
+- O
+- O
+id: CHEBI:17201
+is_organic: true
+name: glycylglycine
+smiles_string: C(C(=O)NCC(=O)O)N
+type: chemrof:Peptide
 
 ```
-## Isotope-deuterium
+## UnchargedAtom-hydrogen
 ### Input
 ```yaml
 atomic_number: 1
-has_element: H
-id: CHEBI:29237
-isotope_of: CHEBI:49637
-name: deuterium atom
-neutron_number: 1
-symbol: H
-type: chemrof:Isotope
-
-```
-## NeutralMolecule-water
-### Input
-```yaml
 elemental_charge: 0
-has_atoms:
-- H
-- H
-- O
-id: CHEBI:15377
-is_organic: false
-name: water
-type: chemrof:NeutralMolecule
-
-```
-## SubatomicParticle-proton
-### Input
-```yaml
-id: CHEBI:24636
-name: proton
-subatomic_particle_type: proton
-type: chemrof:SubatomicParticle
-
-```
-## IsomeraseReaction-glucose_isomerase
-### Input
-```yaml
-id: RHEA:28549
-name: glucose isomerase reaction
-type: chemrof:IsomeraseReaction
-
-```
-## FunctionalGroup-carboxyl
-### Input
-```yaml
-empirical_formula: CO2H
-id: CHEBI:46883
-name: carboxy group
-type: chemrof:FunctionalGroup
+id: CHEBI:49637
+name: hydrogen atom
+symbol: H
+type: chemrof:UnchargedAtom
 
 ```
 ## Macromolecule-polyethylene

--- a/examples/output/SmallMolecule-acetic-acid-with-pka.json
+++ b/examples/output/SmallMolecule-acetic-acid-with-pka.json
@@ -1,0 +1,14 @@
+{
+  "id": "CHEBI:15365",
+  "name": "acetic acid",
+  "type": "chemrof:SmallMolecule",
+  "IUPAC_name": "acetic acid",
+  "smiles_string": "CC(=O)O",
+  "empirical_formula": "C2H4O2",
+  "molecular_mass": 60.05,
+  "water_solubility": 1000000.0,
+  "pka_ionization_constant": [
+    4.74
+  ],
+  "@type": "SmallMolecule"
+}

--- a/examples/output/SmallMolecule-acetic-acid-with-pka.yaml
+++ b/examples/output/SmallMolecule-acetic-acid-with-pka.yaml
@@ -1,0 +1,10 @@
+id: CHEBI:15365
+name: acetic acid
+type: chemrof:SmallMolecule
+IUPAC_name: acetic acid
+smiles_string: CC(=O)O
+empirical_formula: C2H4O2
+molecular_mass: 60.05
+water_solubility: 1000000.0
+pka_ionization_constant:
+- 4.74

--- a/examples/output/SmallMolecule-glucose-with-solubility.json
+++ b/examples/output/SmallMolecule-glucose-with-solubility.json
@@ -1,0 +1,11 @@
+{
+  "id": "CHEBI:17234",
+  "name": "glucose",
+  "type": "chemrof:SmallMolecule",
+  "IUPAC_name": "(2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanal",
+  "smiles_string": "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O",
+  "empirical_formula": "CH2O",
+  "molecular_mass": 180.16,
+  "water_solubility": 909.0,
+  "@type": "SmallMolecule"
+}

--- a/examples/output/SmallMolecule-glucose-with-solubility.yaml
+++ b/examples/output/SmallMolecule-glucose-with-solubility.yaml
@@ -1,0 +1,8 @@
+id: CHEBI:17234
+name: glucose
+type: chemrof:SmallMolecule
+IUPAC_name: (2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanal
+smiles_string: C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O
+empirical_formula: CH2O
+molecular_mass: 180.16
+water_solubility: 909.0

--- a/src/chemrof/schema/chemrof.yaml
+++ b/src/chemrof/schema/chemrof.yaml
@@ -112,6 +112,8 @@ classes:
     - empirical_formula
     - has_major_microspecies_at_pH7_3
     - molecular_mass
+    - water_solubility
+    - pka_ionization_constant
     slot_usage:
       inchi_chemical_sublayer:
         required: false
@@ -2239,6 +2241,28 @@ slots:
     exact_mappings:
       - FIX:0000943
     range: string
+
+  water_solubility:
+    description: The maximum amount of a substance that can dissolve in water at 25°C, expressed in grams per liter (g/L).
+    is_a: molecular_property
+    title: water solubility
+    range: float
+    unit:
+      ucum_code: "g/L"
+    comments:
+      - "Standard temperature is 25°C (298.15 K)"
+      - "This property represents the maximum equilibrium solubility in pure water"
+
+  pka_ionization_constant:
+    description: The negative logarithm of the acid dissociation constant (Ka) for ionizable groups in a molecule. Multiple pKa values may exist for molecules with multiple ionizable groups.
+    is_a: molecular_property
+    title: pKa ionization constant
+    range: float
+    multivalued: true
+    comments:
+      - "Lower pKa values indicate stronger acids"
+      - "For molecules with multiple ionizable groups, this field can contain multiple values"
+      - "Standard conditions: aqueous solution at 25°C"
   chemical_representation:
     aliases:
     - has chemical encoding

--- a/src/data/examples/valid/NaturalProduct-caffeine.yaml
+++ b/src/data/examples/valid/NaturalProduct-caffeine.yaml
@@ -29,3 +29,6 @@ has_atoms:
   - O
   - O
 is_organic: true
+water_solubility: 20.0
+pka_ionization_constant:
+  - 10.4

--- a/src/data/examples/valid/SmallMolecule-acetic-acid-with-pka.yaml
+++ b/src/data/examples/valid/SmallMolecule-acetic-acid-with-pka.yaml
@@ -1,0 +1,10 @@
+type: chemrof:SmallMolecule
+id: CHEBI:15365
+name: acetic acid
+IUPAC_name: "acetic acid"
+smiles_string: "CC(=O)O"
+empirical_formula: "C2H4O2"
+molecular_mass: 60.05
+water_solubility: 1000000.0
+pka_ionization_constant:
+  - 4.74

--- a/src/data/examples/valid/SmallMolecule-glucose-with-solubility.yaml
+++ b/src/data/examples/valid/SmallMolecule-glucose-with-solubility.yaml
@@ -1,0 +1,8 @@
+type: chemrof:SmallMolecule
+id: CHEBI:17234
+name: glucose
+IUPAC_name: "(2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanal"
+smiles_string: "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O"
+empirical_formula: "CH2O"
+molecular_mass: 180.16
+water_solubility: 909.0


### PR DESCRIPTION
Summary: This PR addresses GitHub issue #35 by adding water solubility and pKa ionization constant properties to the ChemROF schema.

Changes Made:
- Added water_solubility slot: Fixed unit of g/L at standard temperature (25°C), inheriting from molecular_property
- Added pka_ionization_constant slot: Multivalued float for molecules with multiple ionizable groups
- Updated ChemicalEntity class: Added both new properties to the base chemical entity class

Examples Added:
1. SmallMolecule-glucose-with-solubility.yaml: Demonstrates glucose with 909 g/L water solubility
2. SmallMolecule-acetic-acid-with-pka.yaml: Shows acetic acid with pKa 4.74
3. Updated NaturalProduct-caffeine.yaml: Added water solubility (20 g/L) and pKa (10.4)

All examples validate successfully against the updated schema.

Resolves #35

@dragon-ai-agent