### PR TITLE
Add CXSMILES string slot

### DIFF
--- a/src/chemrof/schema/chemrof.yaml
+++ b/src/chemrof/schema/chemrof.yaml
@@ -109,6 +109,7 @@ classes:
       - inchi_stereochemical_type_sublayer
       - inchi_isotopic_layer
       - smiles_string
+      - cxsmiles_string
       - empirical_formula
       - has_major_microspecies_at_pH7_3
       - molecular_mass
@@ -211,6 +212,7 @@ classes:
       - id
       - smarts_string
       - markush_string
+      - cxsmiles_string
     slot_usage:
       subtype_of:
         range: ChemicalGroupingClass
@@ -2643,11 +2645,30 @@ slots:
     exact_mappings:
       - wd:P2017
     title: isomeric smiles string
-  extended_smiles_string:
+  cxsmiles_string:
     aliases:
       - CXSMILES
+      - ChemAxon extended SMILES
+      - extended SMILES
     is_a: smiles_string
-    title: extended smiles string
+    description: A ChemAxon Extended SMILES string that appends a feature block to a SMILES string to capture annotations such as atom labels, R-groups, S-groups, coordinates, radicals, and enhanced stereochemistry.
+    exact_mappings:
+      - wd:P10718
+    see_also:
+      - https://docs.chemaxon.com/latest/formats_chemaxon-extended-smiles-and-smarts-cxsmiles-and-cxsmarts.html
+    examples:
+      - value: '[H][C@@](COC([*])=O)(COP(O)(=O)O[C@H]1[C@H](O)[C@@H](O)[C@H](O)[C@@H](OP(O)(O)=O)[C@H]1O)OC([*])=O |$;;;;;_R1;;;;;;;;;;;;;;;;;;;;;;;;;_R2$|'
+        description: CXSMILES for 1-phosphatidyl-1D-myo-inositol 3-phosphate (R1,R2)
+    title: CXSMILES string
+  extended_smiles_string:
+    aliases:
+      - extended SMILES
+    is_a: smiles_string
+    deprecated: Use cxsmiles_string instead.
+    deprecated_element_has_exact_replacement: cxsmiles_string
+    comments:
+      - This slot was previously used for CXSMILES, but the primary name was too broad.
+    title: extended smiles string (Deprecated)
   canonical_smiles_string:
     is_a: smiles_string
     abstract: true

--- a/src/data/examples/valid/MoleculeGroupingClass-phosphatidylinositol_3_phosphate_r1_r2.yaml
+++ b/src/data/examples/valid/MoleculeGroupingClass-phosphatidylinositol_3_phosphate_r1_r2.yaml
@@ -1,0 +1,3 @@
+id: wd:Q46220488
+name: 1-phosphatidyl-1D-myo-inositol 3-phosphate (R1,R2)
+cxsmiles_string: "[H][C@@](COC([*])=O)(COP(O)(=O)O[C@H]1[C@H](O)[C@@H](O)[C@H](O)[C@@H](OP(O)(O)=O)[C@H]1O)OC([*])=O |$;;;;;_R1;;;;;;;;;;;;;;;;;;;;;;;;;_R2$|"


### PR DESCRIPTION
## Summary

Fixes #64.

This adds a precise CHEMROF slot for CXSMILES using `cxsmiles_string` as the primary name while preserving the older `extended_smiles_string` slot as deprecated metadata.

Changes in this PR:

- add `cxsmiles_string` for CXSMILES values
- expose `cxsmiles_string` on `ChemicalEntity` for concrete chemical records
- expose `cxsmiles_string` on `ChemicalGroupingClass` for generalized/R-group structures like the example in issue #64
- keep `extended_smiles_string` as a deprecated slot and declare `cxsmiles_string` as its exact replacement with `deprecated_element_has_exact_replacement`
- document CXSMILES with aliases, Wikidata `wd:P10718`, and the ChemAxon format reference
- add the issue #64 R1/R2 CXSMILES example as a valid `MoleculeGroupingClass` example

## Rationale

The previous primary name, `extended_smiles_string`, was too broad: several tools and conventions could reasonably be described as extended SMILES. The issue is specifically about CXSMILES, so this PR uses `cxsmiles_string` as the schema-facing name while retaining the previous slot as deprecated for compatibility.

The example in the issue uses R-group placeholders, so it is modeled as a grouping class rather than a concrete fully specified molecule.

## Validation

- `make test-examples`
- `git diff --check`

Generated schema artifacts and generated example-output files are intentionally not committed in this PR.

Some AI assistance was used in preparing this PR (Codex/GPT-5.5).

@dragon-ai-agent