### PR TITLE
Add openclatura enricher for local SMILES-to-IUPAC naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 
+[project.optional-dependencies]
+# Local SMILES-to-IUPAC naming used by the `openclatura` enricher.
+# openclatura requires Python >=3.11, so gate it with a marker to keep the
+# project resolvable on the 3.10 that chemrof still supports.
+openclatura = ["openclatura>=0.1.0; python_version >= '3.11'"]
+
 [tool.uv]
 package = true
 

--- a/src/chemrof/cli/main.py
+++ b/src/chemrof/cli/main.py
@@ -50,6 +50,9 @@ Pass a comma-separated list of source names. Available sources:
   chemont   -- Look up ClassyFire/ChemOnt labels by InChIKey from a
                local DuckDB, Parquet, or TSV source and fills classified_by.
 
+  openclatura -- Derive a systematic IUPAC name locally from the structure
+               (no network). Fills IUPAC_name. Requires `pip install openclatura`.
+
   chebi     -- (stub) Will resolve CHEBI identifiers via OLS.
 
   wikidata  -- (stub) Will resolve Wikidata QIDs via SPARQL.

--- a/src/chemrof/converter/enrichers/base.py
+++ b/src/chemrof/converter/enrichers/base.py
@@ -43,12 +43,14 @@ def _build_registry() -> dict[str, type]:
     """Lazily import enricher classes to avoid circular imports."""
     from chemrof.converter.enrichers.chemont import ChemOntEnricher
     from chemrof.converter.enrichers.pubchem import PubChemEnricher
+    from chemrof.converter.enrichers.openclatura import OpenclaturaEnricher
     from chemrof.converter.enrichers.chebi import ChebiEnricher
     from chemrof.converter.enrichers.wikidata import WikidataEnricher
 
     return {
         "chemont": ChemOntEnricher,
         "pubchem": PubChemEnricher,
+        "openclatura": OpenclaturaEnricher,
         "chebi": ChebiEnricher,
         "wikidata": WikidataEnricher,
     }

--- a/src/chemrof/converter/enrichers/openclatura.py
+++ b/src/chemrof/converter/enrichers/openclatura.py
@@ -1,0 +1,66 @@
+"""openclatura enricher -- generates IUPAC names locally from structure.
+
+Unlike the PubChem enricher, this needs no network: it derives a systematic
+IUPAC name directly from the molecule's SMILES using the ``openclatura``
+package (https://github.com/lamalab-org/openclatura), which walks the
+molecular graph following IUPAC Blue Book 2013 rules.
+
+Fills: IUPAC_name (always, when a name is derived) and name (only when the
+object still carries a placeholder such as the empirical formula, so a better
+name from another enricher is never clobbered).
+
+Install the optional dependency with ``pip install openclatura``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from chemrof.converter.enrichers.base import EnrichmentContext
+
+logger = logging.getLogger(__name__)
+
+
+class OpenclaturaEnricher:
+    """Enrich a chemrof dict with an IUPAC name derived from its SMILES."""
+
+    name = "openclatura"
+
+    def enrich(self, obj: dict, context: EnrichmentContext) -> dict:
+        smiles = context.smiles or obj.get("smiles_string", "")
+        if not smiles:
+            return obj
+        iupac = self._name_smiles(smiles)
+        if iupac:
+            return self._apply_name(obj, iupac)
+        return obj
+
+    def _name_smiles(self, smiles: str) -> str | None:
+        """Return the IUPAC name for *smiles*, or None if unavailable.
+
+        Isolated so the library call can be swapped out in tests.
+        """
+        try:
+            from openclatura import name as oc_name
+        except ImportError:
+            logger.warning(
+                "openclatura is not installed; skipping. "
+                "Install it with `pip install openclatura`."
+            )
+            return None
+        try:
+            result = oc_name(smiles)
+        except Exception as exc:  # openclatura raises on structures it can't name
+            logger.debug("openclatura could not name %s: %s", smiles, exc)
+            return None
+        if getattr(result, "ok", False) and getattr(result, "name", None):
+            return result.name
+        return None
+
+    def _apply_name(self, obj: dict, iupac_name: str) -> dict:
+        """Apply a derived IUPAC name to *obj* without clobbering better names."""
+        obj["IUPAC_name"] = iupac_name
+        current = obj.get("name")
+        if not current or current == obj.get("empirical_formula"):
+            obj["name"] = iupac_name
+        return obj

--- a/src/chemrof/converter/enrichers/openclatura.py
+++ b/src/chemrof/converter/enrichers/openclatura.py
@@ -25,6 +25,7 @@ class OpenclaturaEnricher:
     """Enrich a chemrof dict with an IUPAC name derived from its SMILES."""
 
     name = "openclatura"
+    _warned_missing = False
 
     def enrich(self, obj: dict, context: EnrichmentContext) -> dict:
         smiles = context.smiles or obj.get("smiles_string", "")
@@ -43,10 +44,12 @@ class OpenclaturaEnricher:
         try:
             from openclatura import name as oc_name
         except ImportError:
-            logger.warning(
-                "openclatura is not installed; skipping. "
-                "Install it with `pip install openclatura`."
-            )
+            if not self._warned_missing:
+                logger.warning(
+                    "openclatura is not installed; skipping. "
+                    "Install it with `pip install 'chemrof[openclatura]'`."
+                )
+                self._warned_missing = True
             return None
         try:
             result = oc_name(smiles)

--- a/src/docs/cli.md
+++ b/src/docs/cli.md
@@ -148,6 +148,7 @@ chemrof convert CCO --enrichers pubchem,chebi
 |--------|--------|-------------|
 | `pubchem` | Working | Preferred IUPAC name and PubChem CID (via InChIKey lookup) |
 | `chemont` | Working | Ordered ChemOnt/ClassyFire tree classes in `classified_by` (via local lookup store) |
+| `openclatura` | Working | Systematic `IUPAC_name` derived locally from the structure, no network (via [openclatura](https://github.com/lamalab-org/openclatura); needs `pip install 'chemrof[openclatura]'`) |
 | `chebi` | Stub | Will resolve CHEBI identifiers via OLS |
 | `wikidata` | Stub | Will resolve Wikidata QIDs via SPARQL |
 

--- a/src/docs/converter.md
+++ b/src/docs/converter.md
@@ -113,6 +113,18 @@ locally-derived name everywhere else:
 chemrof convert "CCO" --enrichers pubchem,openclatura
 ```
 
+The `IUPAC_name` slot carries an `owl: AnnotationAssertion` interpretation, so
+the enrichment flows straight through to OWL output — no extra wiring needed:
+
+```bash
+chemrof convert "CC(=O)Nc1ccccc1" --enrichers openclatura --format owl
+```
+
+```
+AnnotationAssertion(rdfs:label <.../FZERHIULMFGESH-UHFFFAOYSA-N> "N-phenylacetamide")
+AnnotationAssertion(chemrof:IUPAC_name <.../FZERHIULMFGESH-UHFFFAOYSA-N> "N-phenylacetamide")
+```
+
 ### ChemOnt classification examples
 
 Prepare a local DuckDB lookup store directly from the Zenodo release:

--- a/src/docs/converter.md
+++ b/src/docs/converter.md
@@ -78,6 +78,7 @@ and a PubChem CID cross-reference.
 |------|--------|-------------|
 | `pubchem` | Working | Looks up the compound in PubChem by InChIKey. Fills `name` (IUPAC preferred) and `pubchem_cid`. |
 | `chemont` | Working | Looks up the compound in a local ChemOnt/ClassyFire store by InChIKey. Fills `classified_by` with the ordered ChemOnt path. |
+| `openclatura` | Working | Derives a systematic IUPAC name locally from the structure (no network) via [openclatura](https://github.com/lamalab-org/openclatura). Fills `IUPAC_name`. Requires the optional dependency (`pip install 'chemrof[openclatura]'`). |
 | `chebi` | Stub | Will resolve CHEBI identifiers via the OLS API. |
 | `wikidata` | Stub | Will resolve Wikidata QIDs via SPARQL. |
 
@@ -85,6 +86,31 @@ Multiple enrichers run in sequence:
 
 ```bash
 chemrof convert "CCO" --enrichers pubchem,chemont --chemont-source chemont.duckdb
+```
+
+### Local IUPAC naming (openclatura)
+
+The `openclatura` enricher derives a systematic IUPAC name straight from the
+structure, with no network lookup, so it also names compounds that are not in
+any database. Install the optional dependency first:
+
+```bash
+pip install 'chemrof[openclatura]'
+```
+
+Then request it like any other enricher:
+
+```bash
+chemrof convert "CC(=O)Nc1ccccc1" --enrichers openclatura
+```
+
+It fills `IUPAC_name` (here, `N-phenylacetamide`) and also sets `name` when
+that slot still holds a placeholder such as the empirical formula. Running it
+alongside `pubchem` gives a database-preferred name where one exists and a
+locally-derived name everywhere else:
+
+```bash
+chemrof convert "CCO" --enrichers pubchem,openclatura
 ```
 
 ### ChemOnt classification examples

--- a/tests/test_enricher_openclatura.py
+++ b/tests/test_enricher_openclatura.py
@@ -1,0 +1,91 @@
+"""Tests for the openclatura enricher.
+
+The name-application logic is exercised without importing the optional
+``openclatura`` package, so these tests run even when it is not installed.
+"""
+
+import pytest
+
+from chemrof.converter.enrichers.base import EnrichmentContext
+from chemrof.converter.enrichers.openclatura import OpenclaturaEnricher
+
+
+@pytest.fixture
+def enricher():
+    return OpenclaturaEnricher()
+
+
+def _ctx(smiles: str = "") -> EnrichmentContext:
+    return EnrichmentContext(mol=None, inchikey="", smiles=smiles, inchi="")
+
+
+def test_openclatura_enricher_name(enricher):
+    assert enricher.name == "openclatura"
+
+
+def test_apply_name_sets_iupac_name(enricher):
+    """IUPAC_name is always filled from the derived name."""
+    obj = {"id": "INCHIKEY:LFQSCWFLJHTTHZ-UHFFFAOYSA-N", "name": "C2H6O",
+           "empirical_formula": "C2H6O"}
+    result = enricher._apply_name(obj, "ethanol")
+    assert result["IUPAC_name"] == "ethanol"
+
+
+def test_apply_name_replaces_formula_placeholder(enricher):
+    """A name that is still just the empirical formula is upgraded."""
+    obj = {"name": "C2H6O", "empirical_formula": "C2H6O"}
+    result = enricher._apply_name(obj, "ethanol")
+    assert result["name"] == "ethanol"
+
+
+def test_apply_name_preserves_existing_name(enricher):
+    """A real name (e.g. from PubChem) is not clobbered."""
+    obj = {"name": "grain alcohol", "empirical_formula": "C2H6O"}
+    result = enricher._apply_name(obj, "ethanol")
+    assert result["name"] == "grain alcohol"
+    assert result["IUPAC_name"] == "ethanol"
+
+
+def test_apply_name_fills_missing_name(enricher):
+    obj = {"empirical_formula": "C2H6O"}
+    result = enricher._apply_name(obj, "ethanol")
+    assert result["name"] == "ethanol"
+
+
+def test_enrich_no_smiles_is_noop(enricher):
+    """Without a SMILES there is nothing to name."""
+    obj = {"name": "C2H6O"}
+    result = enricher.enrich(obj, _ctx(smiles=""))
+    assert result == {"name": "C2H6O"}
+
+
+def test_enrich_uses_injected_naming(monkeypatch, enricher):
+    """enrich() applies whatever _name_smiles returns."""
+    monkeypatch.setattr(enricher, "_name_smiles", lambda smiles: "ethanol")
+    obj = {"name": "C2H6O", "empirical_formula": "C2H6O"}
+    result = enricher.enrich(obj, _ctx(smiles="CCO"))
+    assert result["IUPAC_name"] == "ethanol"
+    assert result["name"] == "ethanol"
+
+
+def test_enrich_naming_failure_leaves_obj_unchanged(monkeypatch, enricher):
+    monkeypatch.setattr(enricher, "_name_smiles", lambda smiles: None)
+    obj = {"name": "C2H6O", "empirical_formula": "C2H6O"}
+    result = enricher.enrich(obj, _ctx(smiles="CCO"))
+    assert "IUPAC_name" not in result
+    assert result["name"] == "C2H6O"
+
+
+def test_name_smiles_missing_package_returns_none(monkeypatch, enricher):
+    """When openclatura is not importable, _name_smiles degrades gracefully."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "openclatura":
+            raise ImportError("no openclatura")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert enricher._name_smiles("CCO") is None

--- a/tests/test_enricher_openclatura.py
+++ b/tests/test_enricher_openclatura.py
@@ -6,7 +6,7 @@ The name-application logic is exercised without importing the optional
 
 import pytest
 
-from chemrof.converter.enrichers.base import EnrichmentContext
+from chemrof.converter.enrichers.base import Enricher, EnrichmentContext
 from chemrof.converter.enrichers.openclatura import OpenclaturaEnricher
 
 
@@ -21,6 +21,10 @@ def _ctx(smiles: str = "") -> EnrichmentContext:
 
 def test_openclatura_enricher_name(enricher):
     assert enricher.name == "openclatura"
+
+
+def test_openclatura_follows_enricher_protocol(enricher):
+    assert isinstance(enricher, Enricher)
 
 
 def test_apply_name_sets_iupac_name(enricher):

--- a/tests/test_enricher_registry.py
+++ b/tests/test_enricher_registry.py
@@ -10,6 +10,7 @@ def test_list_enrichers():
     names = list_enrichers()
     assert "chemont" in names
     assert "pubchem" in names
+    assert "openclatura" in names
     assert "chebi" in names
     assert "wikidata" in names
 

--- a/tests/test_owl_output.py
+++ b/tests/test_owl_output.py
@@ -62,6 +62,15 @@ class TestDictsToOwl:
         owl = dicts_to_owl([obj])
         assert "label" in owl
 
+    def test_iupac_name_annotation_assertion(self, converter):
+        """An IUPAC_name (as the openclatura enricher fills) becomes an
+        OWL AnnotationAssertion, composing enrichment with OWL generation."""
+        obj = converter.convert("CC(=O)Nc1ccccc1")
+        obj["IUPAC_name"] = "N-phenylacetamide"
+        owl = dicts_to_owl([obj])
+        assert "AnnotationAssertion(chemrof:IUPAC_name" in owl
+        assert "N-phenylacetamide" in owl
+
     def test_classified_by_outputs_subclass_axioms(self, converter):
         obj = converter.convert("CCO")
         obj["classified_by"] = ["CHEMONTID:0000000", "CHEMONTID:0000286"]


### PR DESCRIPTION
Adds a new `openclatura` enricher plugin that derives systematic IUPAC
names directly from a molecule's structure using the openclatura package
(https://github.com/lamalab-org/openclatura), which walks the molecular
graph following IUPAC Blue Book 2013 rules.

Unlike the existing `pubchem` enricher, this needs no network access and
works for structures not present in any database. It fills the IUPAC_name
slot, and upgrades `name` only when it still holds a placeholder (e.g. the
empirical formula) so a better name from another enricher is never
clobbered.

Changes:
- New OpenclaturaEnricher (src/chemrof/converter/enrichers/openclatura.py)
  with lazy, graceful import so it is a no-op when the optional package is
  not installed.
- Registered `openclatura` in the enricher registry and documented it in
  the CLI --enrichers help text.
- Declared `openclatura` as an optional dependency (pip install
  'chemrof[openclatura]'), marker-gated to python>=3.11 since openclatura
  requires it while chemrof still supports 3.10.
- Tests: dedicated test_enricher_openclatura.py (naming-application logic
  runs without the optional package) plus registry coverage.

Signed-off-by: @dragon-ai-agent

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nkkin3NwvuXRvuS5uka3CP